### PR TITLE
Updated to https

### DIFF
--- a/pynv/__init__.py
+++ b/pynv/__init__.py
@@ -9,7 +9,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-API_BASE_URL = 'http://neurovault.org/api/'
+API_BASE_URL = 'https://neurovault.org/api/'
 
 from .client import Client
 


### PR DESCRIPTION
Neurovault now supports https. 

For some reason, some routes (such as pushing images), only work over https. I've tested this manually. I tried updating the tests's cassettes but some collection numbers were hardcoded in and hard to replicate. 